### PR TITLE
Fix objc hash syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ logger.postLog(["recipe_id": "123"], tag: "pv.recipe_detail")
 ```objective-c
 // Objective-C
 
-[logger postLog:@[@"recipe_id": @"123"] tag: @"pv.recipe_detail"]
+[logger postLog:@{@"recipe_id": @"123"} tag: @"pv.recipe_detail"]
 ```
 
 ### Plugins


### PR DESCRIPTION
Hi @slightair , thanks for the great plugin.

I accidentally found this.
