### PR TITLE
Modify pessimistic version for YapDatabase

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - CocoaLumberjack/Extensions (2.4.0):
     - CocoaLumberjack/Default
   - Puree (2.0.1):
-    - YapDatabase (~> 2.9.2)
+    - YapDatabase (~> 2.9)
   - Reachability (3.2)
   - YapDatabase (2.9.2):
     - YapDatabase/Standard (= 2.9.2)
@@ -70,10 +70,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
-  Puree: 33d528d639daddf0cee74ec6125f96072c9251c3
+  Puree: 6c90e24d4c410d32c5516d2bf68a5dd35c7aaa6e
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
 
 PODFILE CHECKSUM: af5047754632caf7b29086116f921595e64a2970
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.1

--- a/Example/Puree.xcodeproj/project.pbxproj
+++ b/Example/Puree.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E5B5611B77683DE75002CEFD /* [CP] Embed Pods Frameworks */ = {

--- a/Puree.podspec
+++ b/Puree.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes'
 
-  s.dependency 'YapDatabase', '~> 2.9.2'
+  s.dependency 'YapDatabase', '~> 2.9'
 end


### PR DESCRIPTION
YapDatabase 2.9.3 is already released.
However, Puree uses the older one.

To suppress the warning, I'd like to use newest.
So I modified dependencies version.

@slightair Please review it :pray: