### PR TITLE
Make buffer list in PURBufferedOutput Thread Safe

### DIFF
--- a/Pod/Classes/PURBufferCollection.h
+++ b/Pod/Classes/PURBufferCollection.h
@@ -1,0 +1,21 @@
+//
+//  PURBufferCollection.h
+//  Pods
+//
+//  Created by atsushi.sakai on 2017/09/29.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "PURLog.h"
+
+@interface PURBufferCollection : NSObject
+
+- (NSUInteger)count;
+- (void)addLog:(PURLog *)log;
+- (void)addLogs:(NSArray<PURLog *> *)logs;
+- (void)removeAtIndexes:(NSIndexSet *)indexSet;
+- (void)removeAll;
+- (NSArray<PURLog *> *)logsAtIndexSet:(NSIndexSet *)indexSet;
+
+@end

--- a/Pod/Classes/PURBufferCollection.m
+++ b/Pod/Classes/PURBufferCollection.m
@@ -1,0 +1,71 @@
+//
+//  PURBufferCollection.m
+//  Pods
+//
+//  Created by atsushi.sakai on 2017/09/29.
+//
+//
+
+#import "PURBufferCollection.h"
+#import "PURLog.h"
+
+@interface PURBufferCollection()
+
+@property (nonatomic) NSMutableArray<PURLog *> *buffer;
+
+@end
+
+@implementation PURBufferCollection
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.buffer = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (NSUInteger)count
+{
+    @synchronized (self) {
+        return [self.buffer count];
+    }
+}
+
+- (void)addLog:(PURLog *)log
+{
+    @synchronized (self) {
+        [self.buffer addObject:log];
+    }
+}
+
+- (void)addLogs:(NSArray<PURLog *> *)logs
+{
+    @synchronized (self) {
+        [self.buffer addObjectsFromArray:logs];
+    }
+}
+
+- (void)removeAtIndexes:(NSIndexSet *)indexSet
+{
+    @synchronized (self) {
+        [self.buffer removeObjectsAtIndexes:indexSet];
+    }
+}
+
+- (void)removeAll
+{
+    @synchronized (self) {
+        [self.buffer removeAllObjects];
+    }
+}
+
+- (NSArray<PURLog *> *)logsAtIndexSet:(NSIndexSet *)indexSet
+{
+    @synchronized (self) {
+        return [self.buffer objectsAtIndexes:indexSet];
+    }
+}
+
+@end

--- a/Pod/Classes/PURBufferedOutput.m
+++ b/Pod/Classes/PURBufferedOutput.m
@@ -1,6 +1,7 @@
 #import "PURBufferedOutput.h"
 #import "PURLogStore.h"
 #import "PURLog.h"
+#import "PURBufferCollection.h"
 
 NSString * const PURBufferedOutputSettingsLogLimitKey = @"BufferedOutputLogLimit";
 NSString * const PURBufferedOutputSettingsFlushIntervalKey = @"BufferedOutputFlushInterval";
@@ -32,7 +33,7 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 
 @interface PURBufferedOutput ()
 
-@property (nonatomic) NSMutableArray<PURLog *> *buffer;
+@property (nonatomic) PURBufferCollection *buffer;
 @property (nonatomic) NSUInteger logLimit;
 @property (nonatomic) NSTimeInterval flushInterval;
 @property (nonatomic) NSUInteger maxRetryCount;
@@ -74,21 +75,21 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
     value = settings[PURBufferedOutputSettingsMaxRetryCountKey];
     self.maxRetryCount = value ? [value unsignedIntegerValue] : PURBufferedOutputDefaultMaxRetryCount;
 
-    self.buffer = [NSMutableArray new];
+    self.buffer = [PURBufferCollection new];
 }
 
 - (void)start
 {
     [super start];
 
-    [self removeAllBuffer];
+    [self.buffer removeAll];
     [self retrieveLogs:^(NSArray<PURLog *> * _Nonnull logs){
         [[NSNotificationCenter defaultCenter] postNotificationName:PURBufferedOutputDidStartNotification object:self];
 
         if (![self.timer isValid]) {
             return;
         }
-        [self addLogsToBuffer:logs];
+        [self.buffer addLogs:logs];
         [self flush];
     }];
 
@@ -99,14 +100,14 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 {
     [super resume];
 
-    [self removeAllBuffer];
+    [self.buffer removeAll];
     [self retrieveLogs:^(NSArray<PURLog *> * _Nonnull logs){
         [[NSNotificationCenter defaultCenter] postNotificationName:PURBufferedOutputDidResumeNotification object:self];
 
         if (![self.timer isValid]) {
             return;
         }
-        [self addLogsToBuffer:logs];
+        [self.buffer addLogs:logs];
         [self flush];
     }];
 
@@ -129,14 +130,14 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 
 - (void)retrieveLogs:(PURLogStoreRetrieveCompletionBlock)completion
 {
-    [self removeAllBuffer];
+    [self.buffer removeAll];
     [self.logStore retrieveLogsForOutput:self
                               completion:completion];
 }
 
 - (void)emitLog:(PURLog *)log
 {
-    [self addLogToBuffer:log];
+    [self.buffer addLog:log];
     [self.logStore addLog:log forOutput:self completion:^{
         if ([self.buffer count] >= self.logLimit) {
             [self flush];
@@ -154,8 +155,8 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 
     NSUInteger logCount = MIN([self.buffer count], self.logLimit);
     NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, logCount)];
-    NSArray<PURLog *> *flushLogs = [self bufferedLogsAtIndexSet:indexSet];
-    [self removeBuffersAtIndexes:indexSet];
+    NSArray<PURLog *> *flushLogs = [self.buffer logsAtIndexSet:indexSet];
+    [self.buffer removeAtIndexes:indexSet];
 
     PURBufferedOutputChunk *chunk = [[PURBufferedOutputChunk alloc] initWithLogs:flushLogs];
     [self callWriteChunk:chunk];
@@ -191,47 +192,6 @@ NSUInteger PURBufferedOutputDefaultMaxRetryCount = 3;
 - (void)writeChunk:(PURBufferedOutputChunk *)chunk completion:(void (^)(BOOL))completion
 {
     completion(YES);
-}
-
-- (NSUInteger)countBuffers
-{
-    @synchronized (self) {
-        return [self.buffer count];
-    }
-}
-
-- (void)addLogToBuffer:(PURLog *)log
-{
-    @synchronized (self) {
-        [self.buffer addObject:log];
-    }
-}
-
-- (void)addLogsToBuffer:(NSArray<PURLog *> *)logs
-{
-    @synchronized (self) {
-        [self.buffer addObjectsFromArray:logs];
-    }
-}
-
-- (void)removeBuffersAtIndexes:(NSIndexSet *)indexSet
-{
-    @synchronized (self) {
-        [self.buffer removeObjectsAtIndexes:indexSet];
-    }
-}
-
-- (void)removeAllBuffer {
-    @synchronized (self) {
-        [self.buffer removeAllObjects];
-    }
-}
-
-- (NSArray<PURLog *> *)bufferedLogsAtIndexSet:(NSIndexSet *)indexSet
-{
-    @synchronized (self) {
-        return [self.buffer objectsAtIndexes:indexSet];
-    }
 }
 
 @end


### PR DESCRIPTION
Hello.

When I handled `PURBufferdOutput` with multiple threads, I encountered the following crash.

```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x183a57d38 __exceptionPreprocess
1  libobjc.A.dylib                0x182f6c528 objc_exception_throw
2  CoreFoundation                 0x1839f0c44 _CFArgv
3  CoreFoundation                 0x183923e94 -[__NSPlaceholderArray initWithObjects:count:]
4  CoreFoundation                 0x18392fd5c +[NSArray arrayWithObjects:count:]
5  CoreFoundation                 0x183943b88 -[NSArray objectsAtIndexes:]
6  AppName                        0x10089ebac -[PURBufferedOutput flush] (PURBufferedOutput.m:157)
7  AppName                        0x10089e594 __26-[PURBufferedOutput start]_block_invoke (PURBufferedOutput.m:93)
8  libdispatch.dylib              0x1833dd088 _dispatch_call_block_and_release
9  libdispatch.dylib              0x1833dd048 _dispatch_client_callout
10 libdispatch.dylib              0x18341ddfc _dispatch_main_queue_callback_4CF$VARIANT$armv81
11 CoreFoundation                 0x1839fff20 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
12 CoreFoundation                 0x1839fdafc __CFRunLoopRun
13 CoreFoundation                 0x18391e2d8 CFRunLoopRunSpecific
14 GraphicsServices               0x1857aff84 GSEventRunModal
15 UIKit                          0x18ceca880 UIApplicationMain
16 AppName                        0x100ac05b4 main (main.m:22)
17 libdyld.dylib                  0x18344256c start
```

So I made Thread Safe `PURBufferCollection` Class.
`PURBufferedOutput` can avoid crashing by handling buffer logs via this class.

Please review my code and release new version if possible.
Thanks.